### PR TITLE
fix(ui): correct static file serving and MIME types for dashboard

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -112,15 +112,22 @@ export function createApp(config: ServerConfig = DEFAULT_CONFIG): Application {
     maxAge: '1d', // Cache static assets for 1 day
     etag: true,
     lastModified: true,
-    setHeaders: (res, path) => {
+    setHeaders: (res, filePath) => {
       // Security headers for static assets
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('X-Frame-Options', 'DENY');
       
-      // Cache control for different file types
-      if (path.endsWith('.html')) {
+      // Set proper MIME types for different file types
+      if (filePath.endsWith('.css')) {
+        res.setHeader('Content-Type', 'text/css');
+        res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day
+      } else if (filePath.endsWith('.js')) {
+        res.setHeader('Content-Type', 'text/javascript');
+        res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day
+      } else if (filePath.endsWith('.html')) {
+        res.setHeader('Content-Type', 'text/html');
         res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-      } else if (path.match(/\.(css|js|png|jpg|jpeg|gif|ico|svg)$/)) {
+      } else if (filePath.match(/\.(png|jpg|jpeg|gif|ico|svg)$/)) {
         res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day
       }
     }

--- a/src/ui/public/index.html
+++ b/src/ui/public/index.html
@@ -7,8 +7,8 @@
     <meta name="keywords" content="test automation, self-healing, AI, testing, orchestration">
     <meta name="author" content="Self-Healing Test Automation Harness">
     <title>Self-Healing Test Automation Harness - Dashboard</title>
-    <link rel="stylesheet" href="css/dashboard.css">
-    <link rel="stylesheet" href="css/overview.css">
+    <link rel="stylesheet" href="/static/css/dashboard.css">
+    <link rel="stylesheet" href="/static/css/overview.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -269,8 +269,8 @@
     </footer>
 
     <!-- JavaScript -->
-    <script src="js/api-service.js"></script>
-    <script src="js/dashboard-overview.js"></script>
-    <script src="js/dashboard.js"></script>
+    <script src="/static/js/api-service.js"></script>
+    <script src="/static/js/dashboard-overview.js"></script>
+    <script src="/static/js/dashboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Fix Express static file MIME types (CSS/JS served as text/html)
- Update HTML paths to use /static/ prefix for CSS and JS files
- Add explicit Content-Type headers in Express setHeaders callback
- Ensure proper browser loading of stylesheets and scripts