### PR TITLE
feat(ci): transition develop branch from alpha to beta channel

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,7 @@
     {
       "name": "develop",
       "prerelease": true,
-      "channel": "alpha"
+      "channel": "beta"
     }
   ],
   "plugins": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,15 +127,15 @@ When you run `git commit` without a message, vim will open with the template sho
 
 #### Current MVP Workflow
 - **main**: Production releases (v0.8.0+)
-- **develop**: Pre-release staging branch (currently alpha, future beta)
+- **develop**: Pre-release staging branch (currently beta channel)
 - **feature/***: New features (merge to develop)
 - **fix/***: Bug fixes (merge to develop)
 - **docs/***: Documentation updates (merge to develop)
 
 #### Release Strategy Evolution
-- **Phase 1**: `develop` = alpha development (v0.6.x-alpha.x)
-- **Phase 2**: `develop` = pre-release staging → `main` = production (v0.8.0+)
-- **Phase 3**: `develop` = beta channel (v0.8.x-beta.x) → `main` = production
+- **Phase 1 (Completed)**: `develop` = alpha development (v0.6.x-alpha.x)
+- **Phase 2 (Completed)**: `develop` = pre-release staging → `main` = production (v0.8.0+)
+- **Phase 3 (Current)**: `develop` = beta channel (v0.8.x-beta.x) → `main` = production
 
 ### Pull Request Process
 1. Create a feature branch from `develop`
@@ -303,7 +303,7 @@ This project uses automated semantic versioning with [semantic-release](https://
 2. **CI Workflow**: Pull requests to `develop` or `main` trigger validation (build, test, type-check, lint)
 3. **Deploy Workflow**: Push to `develop` or `main` triggers deployment pipeline
 4. semantic-release analyzes commits and determines version bump
-5. **Develop Branch**: Creates alpha/beta pre-releases (v0.7.x-alpha.x)
+5. **Develop Branch**: Creates beta pre-releases (v0.8.x-beta.x)
 6. **Main Branch**: Creates production releases (v0.8.0+)
 7. GitHub release is created with changelog and artifacts
 8. Version is updated in `package.json` and `CHANGELOG.md` automatically

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Self-Healing Test Automation Harness
 
-> **🔧 PRE-PRODUCTION** - Release Configuration Updated for Production Deployment
+> **🚀 PRODUCTION READY** - Comprehensive Test Automation Platform with AI-Powered Self-Healing
 
 A comprehensive TypeScript/Node.js test automation platform that orchestrates multiple test types (unit, e2e, performance, security) with AI-powered self-healing capabilities.
 
@@ -344,7 +344,7 @@ npm run test:coverage
 
 ## 🎯 Release Roadmap & Status
 
-### ✅ Pre-Production Ready Features (v0.7.0)
+### ✅ Production Ready Features (v0.8.0+)
 - [x] Project foundation and build system
 - [x] Plugin architecture implementation
 - [x] Configuration management system
@@ -391,7 +391,7 @@ npm run test:coverage
 - **✅ Configuration**: Comprehensive Playwright configuration system
 - **✅ Documentation**: Complete documentation and examples
 
-> **📝 Note**: The pre-production harness with comprehensive CI/CD pipeline, Infrastructure-as-Code configuration, and 958 passing tests is ready for production deployment via develop → main workflow.
+> **📝 Note**: The production-ready harness with comprehensive CI/CD pipeline, Infrastructure-as-Code configuration, and 958 passing tests is actively deployed via develop (beta) → main (production) workflow.
 
 ## 📄 License
 

--- a/agents.md
+++ b/agents.md
@@ -460,13 +460,13 @@ The project implements a streamlined DevOps workflow using Infrastructure-as-Cod
 ```
 .github/workflows/
 ├── ci.yml        # PR validation for develop and main branches
-└── deploy.yml    # Unified deployment for alpha and production releases
+└── deploy.yml    # Unified deployment for beta and production releases
 ```
 
 ### Release Strategy Evolution
-- **Phase 1 (Current)**: `develop` = alpha branch (v0.6.x-alpha.x)
-- **Phase 2 (Post-Merge)**: `develop` = pre-release staging, `main` = production (v0.8.0+)
-- **Phase 3 (Future)**: `develop` = beta channel (v0.8.x-beta.x), `main` = production
+- **Phase 1 (Completed)**: `develop` = alpha branch (v0.6.x-alpha.x)
+- **Phase 2 (Completed)**: `develop` = pre-release staging, `main` = production (v0.8.0+)
+- **Phase 3 (Current)**: `develop` = beta channel (v0.8.x-beta.x), `main` = production
 
 ### CI/CD Implementation Standards
 - **ALWAYS** validate PRs with comprehensive quality gates (build, test, type-check, lint)
@@ -485,7 +485,7 @@ The project implements a streamlined DevOps workflow using Infrastructure-as-Cod
     {
       "name": "develop",
       "prerelease": true,
-      "channel": "alpha"       // Pre-release channel (future: beta)
+      "channel": "beta"        // Pre-release channel (current: beta)
     }
   ],
   "plugins": [
@@ -513,10 +513,10 @@ The project implements a streamlined DevOps workflow using Infrastructure-as-Cod
 - **Security**: Automated dependency scanning and vulnerability checks
 
 ### Future Task Management
-- **Task ID**: `5272fa59-8a0a-4a1e-a243-8ccbea7e6319`
+- **Task ID**: `5272fa59-8a0a-4a1e-a243-8ccbea7e6319` ✅ **COMPLETED**
 - **Purpose**: Transition develop branch from alpha to beta channel
-- **Timing**: After first production release (v0.8.0)
-- **Critical**: Maintains proper semantic versioning progression
+- **Timing**: After first production release (v0.8.0) ✅ **COMPLETED**
+- **Critical**: Maintains proper semantic versioning progression ✅ **ACHIEVED**
 
 ## Decision-Making Guidelines
 

--- a/shrimp-rules.md
+++ b/shrimp-rules.md
@@ -1102,9 +1102,9 @@ class Logger {
 - **✅ Quality Gates**: Build, test, type-check, and lint validation before deployment
 
 #### Release Strategy Evolution
-- **Phase 1 (Current)**: `develop` = alpha development branch (v0.6.x-alpha.x)
-- **Phase 2 (Active)**: `develop` = pre-release staging, `main` = production (v0.8.0+)  
-- **Phase 3 (Future)**: `develop` = beta channel (v0.8.x-beta.x), `main` = production
+- **Phase 1 (Completed)**: `develop` = alpha development branch (v0.6.x-alpha.x)
+- **Phase 2 (Completed)**: `develop` = pre-release staging, `main` = production (v0.8.0+)  
+- **Phase 3 (Current)**: `develop` = beta channel (v0.8.x-beta.x), `main` = production
 
 #### Infrastructure-as-Code Standards
 - **ALWAYS** use unified deployment workflows that handle multiple branch strategies
@@ -1123,10 +1123,10 @@ class Logger {
 - **NEVER** deploy without passing all quality gates and comprehensive test validation
 
 #### Future Task Management
-- **Shrimp Task ID**: `5272fa59-8a0a-4a1e-a243-8ccbea7e6319`
+- **Shrimp Task ID**: `5272fa59-8a0a-4a1e-a243-8ccbea7e6319` ✅ **COMPLETED**
 - **Purpose**: Transition develop branch from alpha to beta channel
-- **Timing**: After first production release (v0.8.0) deployment
-- **Critical**: Maintains semantic versioning progression and proper channel management
+- **Timing**: After first production release (v0.8.0) deployment ✅ **COMPLETED**
+- **Critical**: Maintains semantic versioning progression and proper channel management ✅ **ACHIEVED**
 
 ## Prohibited Actions
 


### PR DESCRIPTION
- Update .releaserc.json to change develop branch channel from alpha to beta
- Update documentation to reflect Phase 3 (Current) develop=beta, main=production workflow
- Update README.md to remove pre-production status and reflect production-ready state
- Mark Shrimp task 5272fa59-8a0a-4a1e-a243-8ccbea7e6319 as completed
- Maintain semantic versioning progression: alpha → beta → production